### PR TITLE
Continue tests after a crash when using isolated = false

### DIFF
--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Script to build AndroidX Test m2repository and install orchestrator APKs
+# Based on CONTRIBUTING.md instructions
+
+set -e  # Exit on any error
+
+echo "🔨 Building AndroidX Test m2repository..."
+bazelisk build :axt_m2repository
+
+echo "📦 Unpacking m2repository to ~/.m2/"
+unzip -o bazel-bin/axt_m2repository.zip -d ~/.m2/
+
+echo "📱 Installing orchestrator and services APKs..."
+
+# Find and install test services APK
+SERVICES_APK=~/.m2/repository/androidx/test/services/test-services/1.7.0-alpha01/test-services-1.7.0-alpha01.apk
+if [ -n "$SERVICES_APK" ]; then
+    echo "Installing test services APK: $SERVICES_APK"
+    adb install --force-queryable -r "$SERVICES_APK"
+else
+    echo "❌ Test services APK not found in ~/.m2/repository"
+    exit 1
+fi
+
+# Find and install orchestrator APK  
+ORCHESTRATOR_APK=~/.m2/repository/androidx/test/orchestrator/1.7.0-alpha01/orchestrator-1.7.0-alpha01.apk
+if [ -n "$ORCHESTRATOR_APK" ]; then
+    echo "Installing orchestrator APK: $ORCHESTRATOR_APK"
+    adb install --force-queryable -r "$ORCHESTRATOR_APK"
+else
+    echo "❌ Orchestrator APK not found in ~/.m2/repository"
+    exit 1
+fi
+
+echo "✅ Build and installation complete!"

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/AndroidTestOrchestrator.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/AndroidTestOrchestrator.java
@@ -143,8 +143,13 @@ public final class AndroidTestOrchestrator extends android.app.Instrumentation
     public void testFailure(ParcelableFailure failure) {
         isRecoveringFromCrash = true;
     }
-  }
 
+    @Override
+    public void testProcessFinished(String message) {
+      super.testProcessFinished(message);
+      Log.i(TAG, "Test process finished: " + message);
+    }
+  }
 
   private static final String TAG = "AndroidTestOrchestrator";
   // As defined in the AndroidManifest of the Orchestrator app.
@@ -388,10 +393,12 @@ public final class AndroidTestOrchestrator extends android.app.Instrumentation
     
     // Set test to indicate execution has started
     test = "";
-    // Execute remaining tests using a subset TestRunnable
-    executorService.execute(
-        TestRunnable.testSubsetRunnable(
-            getContext(), getSecret(arguments), arguments, getOutputStream(), this, remainingTests));
+    // Execute remaining tests using a subset TestRunnable, we need to prevent the argument list from being too long
+    // Run 500 tests at a time
+    List<String> remainingTestsSubset = remainingTests.subList(0, Math.min(500, remainingTests.size()));
+            executorService.execute(
+                    TestRunnable.testSubsetRunnable(
+                            getContext(), getSecret(arguments), arguments, getOutputStream(), this, remainingTestsSubset));
   }
 
   private void executeNextTest() {

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/AndroidTestOrchestrator.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/AndroidTestOrchestrator.java
@@ -374,19 +374,16 @@ public final class AndroidTestOrchestrator extends android.app.Instrumentation
       return;
     }
 
-    // We don't actually need test to have any particular value,
-    // just to indicate we've started execution.
-    test = "";
-    executorService.execute(
-        TestRunnable.legacyTestRunnable(
-            getContext(), getSecret(arguments), arguments, getOutputStream(), this));
+    executeRemainingTests();
   }
 
   private void executeRemainingTests() {
+    Log.i(TAG, "Executing remaining tests...");
     // Create a list of remaining tests from the current iterator position
     List<String> remainingTests = new ArrayList<>(testsToExecuteNoIsolation);
     
     if (remainingTests.isEmpty()) {
+      Log.i(TAG, "No remaining tests to execute.");
       finish(Activity.RESULT_OK, createResultBundle());
       return;
     }
@@ -396,9 +393,10 @@ public final class AndroidTestOrchestrator extends android.app.Instrumentation
     // Execute remaining tests using a subset TestRunnable, we need to prevent the argument list from being too long
     // Run 500 tests at a time
     List<String> remainingTestsSubset = remainingTests.subList(0, Math.min(500, remainingTests.size()));
-            executorService.execute(
-                    TestRunnable.testSubsetRunnable(
-                            getContext(), getSecret(arguments), arguments, getOutputStream(), this, remainingTestsSubset));
+    Log.i(TAG, "Executing subset of remaining tests: " + remainingTestsSubset.size() + " tests.");
+    executorService.execute(
+            TestRunnable.testSubsetRunnable(
+                    getContext(), getSecret(arguments), arguments, getOutputStream(), this, remainingTestsSubset));
   }
 
   private void executeNextTest() {

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/TestRunnable.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/TestRunnable.java
@@ -51,24 +51,6 @@ public class TestRunnable implements Runnable {
   private final String secret;
 
   /**
-   * Constructs a TestRunnable executes all tests in arguments.
-   *
-   * @param context A context
-   * @param secret A string representing the speakeasy binder key
-   * @param arguments contains arguments to be passed to the target instrumentation
-   * @param outputStream the stream to write the results of the test process
-   * @param listener a callback listener to know when the run has completed
-   */
-  public static TestRunnable legacyTestRunnable(
-      Context context,
-      String secret,
-      Bundle arguments,
-      OutputStream outputStream,
-      RunFinishedListener listener) {
-    return new TestRunnable(context, secret, arguments, outputStream, listener, null, null, false);
-  }
-
-  /**
    * Constructs a TestRunnable which will run a single test.
    *
    * @param context A context

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/TestRunnable.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/TestRunnable.java
@@ -45,7 +45,7 @@ public class TestRunnable implements Runnable {
   private final RunFinishedListener listener;
   private final OutputStream outputStream;
   private final String test;
-  private final List<String> testSubset;
+  private final String testFilePath;
   private final boolean collectTests;
   private final Context context;
   private final String secret;
@@ -90,14 +90,14 @@ public class TestRunnable implements Runnable {
   }
 
   /**
-   * Constructs a TestRunnable which will run a specific subset of tests.
+   * Constructs a TestRunnable which will run a specific subset of tests from a file.
    *
    * @param context A context
    * @param secret A string representing the speakeasy binder key
    * @param arguments contains arguments to be passed to the target instrumentation
    * @param outputStream the stream to write the results of the test process
    * @param listener a callback listener to know when the run has completed
-   * @param testSubset a list of specific tests to run
+   * @param testFilePath the path to a file containing the tests to run
    */
   public static TestRunnable testSubsetRunnable(
       Context context,
@@ -105,8 +105,8 @@ public class TestRunnable implements Runnable {
       Bundle arguments,
       OutputStream outputStream,
       RunFinishedListener listener,
-      List<String> testSubset) {
-    return new TestRunnable(context, secret, arguments, outputStream, listener, null, testSubset, false);
+      String testFilePath) {
+    return new TestRunnable(context, secret, arguments, outputStream, listener, null, testFilePath, false);
   }
 
   @VisibleForTesting
@@ -117,7 +117,7 @@ public class TestRunnable implements Runnable {
       OutputStream outputStream,
       RunFinishedListener listener,
       String test,
-      List<String> testSubset,
+      String testFilePath,
       boolean collectTests) {
     this.context = context;
     this.secret = secret;
@@ -125,7 +125,7 @@ public class TestRunnable implements Runnable {
     this.outputStream = outputStream;
     this.listener = listener;
     this.test = test;
-    this.testSubset = testSubset;
+    this.testFilePath = testFilePath;
     this.collectTests = collectTests;
   }
 
@@ -183,12 +183,12 @@ public class TestRunnable implements Runnable {
       targetArgs.remove("testFile");
     }
 
-    // Override the class parameter with the current test target or test subset.
+    // Override the class parameter with the current test target or use testFile for test subset.
     if (test != null) {
       targetArgs.putString(AJUR_CLASS_ARGUMENT, test);
-    } else if (testSubset != null && !testSubset.isEmpty()) {
-      // For test subset, create a comma-separated list of tests
-      targetArgs.putString(AJUR_CLASS_ARGUMENT, String.join(",", testSubset));
+    } else if (testFilePath != null && !testFilePath.isEmpty()) {
+      // For test subset, use testFile parameter to read tests from file
+      targetArgs.putString("testFile", testFilePath);
     }
 
     return targetArgs;

--- a/runner/android_test_orchestrator/javatests/androidx/test/orchestrator/TestRunnableTest.java
+++ b/runner/android_test_orchestrator/javatests/androidx/test/orchestrator/TestRunnableTest.java
@@ -59,7 +59,7 @@ public class TestRunnableTest {
         RunFinishedListener listener,
         String test,
         boolean collectTests) {
-      super(context, secret, arguments, outputStream, listener, test, collectTests);
+      super(context, secret, arguments, outputStream, listener, test, null, collectTests);
     }
 
     @Override


### PR DESCRIPTION
This also writes all tests to a file to avoid an argument limit.